### PR TITLE
Fix flashlight/RAGE MODE LED interference bugs

### DIFF
--- a/static/js/keyboard-mouse-control.js
+++ b/static/js/keyboard-mouse-control.js
@@ -957,19 +957,27 @@ class KeyboardMouseControl {
             iconSvg.setAttribute('viewBox', '0 0 262.02 262.02');
             iconSvg.style.filter = 'drop-shadow(0 0 6px rgba(34, 197, 94, 0.5))';
             iconSvg.title = 'POSE MODE ACTIVE — Release SPACE to exit';
-        } else if (!this.rageMode) {
-            // Restore running person icon — teal (only if rage mode is not active)
+        } else {
+            // Restore running person icon
             iconPath.setAttribute('d', RUNNING_PERSON_PATH);
-            iconPath.setAttribute('fill', '#00E8DA');
             iconPath.removeAttribute('stroke');
             iconPath.removeAttribute('stroke-width');
             iconPath.removeAttribute('stroke-linecap');
             iconPath.removeAttribute('stroke-linejoin');
             iconSvg.setAttribute('viewBox', '0 0 24 24');
-            iconSvg.style.filter = 'drop-shadow(0 0 2px black)';
             iconSvg.title = 'RAGE MODE: Bypass all smoothing for raw control (DANGEROUS!)';
+
+            // Restore RAGE MODE visual state if active, otherwise restore normal state
+            if (this.rageMode) {
+                // RAGE MODE is active - restore red color and glow
+                iconPath.setAttribute('fill', '#ef4444');  // Red
+                iconSvg.style.filter = 'drop-shadow(0 0 8px rgba(239, 68, 68, 0.6))';  // Red glow
+            } else {
+                // Normal mode - restore teal color and default shadow
+                iconPath.setAttribute('fill', '#00E8DA');  // Teal
+                iconSvg.style.filter = 'drop-shadow(0 0 2px black)';  // Default shadow
+            }
         }
-        // If rageMode is active, let toggleRageMode handle the icon color
     }
 }
 

--- a/static/js/settings-manager.js
+++ b/static/js/settings-manager.js
@@ -299,12 +299,48 @@ function applyPreset(preset) {
 
     if (presets[preset]) {
         const settings = loadSettings();
-        settings.keyboard_mouse = { ...settings.keyboard_mouse, ...presets[preset].keyboard_mouse };
-        settings.gamepad = { ...settings.gamepad, ...presets[preset].gamepad };
+        // Replace entire objects to ensure exact match with preset (not merge)
+        settings.keyboard_mouse = presets[preset].keyboard_mouse;
+        settings.gamepad = presets[preset].gamepad;
         return saveSettings(settings);
     }
     console.error(`Invalid preset: ${preset}`);
     return false;
+}
+
+/**
+ * Deep compare two objects with tolerance for floating-point precision
+ * @param {Object} obj1 - First object
+ * @param {Object} obj2 - Second object
+ * @returns {boolean} True if objects are equal (with floating-point tolerance)
+ */
+function deepCompareSettings(obj1, obj2) {
+    if (obj1 === obj2) return true;
+    if (obj1 == null || obj2 == null) return false;
+    if (typeof obj1 !== 'object' || typeof obj2 !== 'object') return obj1 === obj2;
+
+    const keys1 = Object.keys(obj1);
+    const keys2 = Object.keys(obj2);
+
+    if (keys1.length !== keys2.length) return false;
+
+    for (const key of keys1) {
+        if (!keys2.includes(key)) return false;
+
+        const val1 = obj1[key];
+        const val2 = obj2[key];
+
+        // For numbers, use tolerance comparison (handles floating-point precision)
+        if (typeof val1 === 'number' && typeof val2 === 'number') {
+            if (Math.abs(val1 - val2) > 0.0001) return false;
+        } else if (typeof val1 === 'object' && typeof val2 === 'object') {
+            if (!deepCompareSettings(val1, val2)) return false;
+        } else {
+            if (val1 !== val2) return false;
+        }
+    }
+
+    return true;
 }
 
 /**
@@ -318,8 +354,8 @@ function getCurrentPreset() {
     for (const preset of presets) {
         const presetSettings = getPresetSettings(preset);
         if (presetSettings &&
-            JSON.stringify(settings.keyboard_mouse) === JSON.stringify(presetSettings.keyboard_mouse) &&
-            JSON.stringify(settings.gamepad) === JSON.stringify(presetSettings.gamepad)) {
+            deepCompareSettings(settings.keyboard_mouse, presetSettings.keyboard_mouse) &&
+            deepCompareSettings(settings.gamepad, presetSettings.gamepad)) {
             return preset;
         }
     }
@@ -339,7 +375,18 @@ function getPresetSettings(preset) {
                 mouse_pitch_sensitivity: 2.0,
                 kb_max_linear_velocity: 2.5,
                 kb_max_strafe_velocity: 0.5,
-                kb_max_rotation_velocity: 1.5
+                kb_max_rotation_velocity: 1.5,
+                linear_alpha: 1.2,
+                strafe_alpha: 1.2,
+                rotation_alpha: 1.2,
+                rotation_deadzone: 0.0,
+                linear_ramp_time: 0.40,
+                strafe_ramp_time: 0.40,
+                rotation_ramp_time: 0.40,
+                pitch_alpha: 1.2,
+                pitch_deadzone: 0.0,
+                pitch_max_velocity: 0.20,
+                pitch_ramp_time: 0.40
             },
             gamepad: {
                 deadzone_left_stick: 0.15,
@@ -359,7 +406,18 @@ function getPresetSettings(preset) {
                 mouse_pitch_sensitivity: 3.0,
                 kb_max_linear_velocity: 3.0,
                 kb_max_strafe_velocity: 0.6,
-                kb_max_rotation_velocity: 2.0
+                kb_max_rotation_velocity: 2.0,
+                linear_alpha: 1.0,
+                strafe_alpha: 1.0,
+                rotation_alpha: 1.0,
+                rotation_deadzone: 0.0,
+                linear_ramp_time: 0.20,
+                strafe_ramp_time: 0.20,
+                rotation_ramp_time: 0.20,
+                pitch_alpha: 1.0,
+                pitch_deadzone: 0.0,
+                pitch_max_velocity: 0.30,
+                pitch_ramp_time: 0.20
             },
             gamepad: {
                 deadzone_left_stick: 0.1,
@@ -379,7 +437,18 @@ function getPresetSettings(preset) {
                 mouse_pitch_sensitivity: 5.0,
                 kb_max_linear_velocity: 4.5,
                 kb_max_strafe_velocity: 0.9,
-                kb_max_rotation_velocity: 3.0
+                kb_max_rotation_velocity: 3.0,
+                linear_alpha: 0.9,
+                strafe_alpha: 0.9,
+                rotation_alpha: 0.9,
+                rotation_deadzone: 0.0,
+                linear_ramp_time: 0.10,
+                strafe_ramp_time: 0.10,
+                rotation_ramp_time: 0.10,
+                pitch_alpha: 0.9,
+                pitch_deadzone: 0.0,
+                pitch_max_velocity: 0.35,
+                pitch_ramp_time: 0.10
             },
             gamepad: {
                 deadzone_left_stick: 0.05,
@@ -399,7 +468,18 @@ function getPresetSettings(preset) {
                 mouse_pitch_sensitivity: 7.5,
                 kb_max_linear_velocity: 5.0,
                 kb_max_strafe_velocity: 1.0,
-                kb_max_rotation_velocity: 3.0
+                kb_max_rotation_velocity: 3.0,
+                linear_alpha: 0.8,
+                strafe_alpha: 0.8,
+                rotation_alpha: 0.8,
+                rotation_deadzone: 0.0,
+                linear_ramp_time: 0.05,
+                strafe_ramp_time: 0.05,
+                rotation_ramp_time: 0.05,
+                pitch_alpha: 0.8,
+                pitch_deadzone: 0.0,
+                pitch_max_velocity: 0.35,
+                pitch_ramp_time: 0.05
             },
             gamepad: {
                 deadzone_left_stick: 0.05,

--- a/templates/control.html
+++ b/templates/control.html
@@ -241,7 +241,7 @@
     <div class="hud-bottom-center">
         <!-- Stand Up Button -->
         <button id="stand-up-btn" class="hud-btn" onclick="sendRobotAction('stand_up')" title="Stand Up (E key)">
-            <svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+            <svg width="60px" height="60px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
                 <path d="M12 17L12 8" stroke="#00E8DA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 <path d="M16 11L12 7L8 11" stroke="#00E8DA" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>
@@ -249,14 +249,14 @@
 
         <!-- Leash Mode Toggle Button -->
         <button id="leash-mode-btn" class="hud-btn" onclick="toggleLeashMode()" title="Toggle Leash Mode (Lead Follow)">
-            <svg id="leash-mode-icon" fill="#00E8DA" width="800px" height="800px" viewBox="-1.5 0 19 19" xmlns="http://www.w3.org/2000/svg" class="cf-icon-svg">
+            <svg id="leash-mode-icon" fill="#00E8DA" width="60px" height="60px" viewBox="-1.5 0 19 19" xmlns="http://www.w3.org/2000/svg" class="cf-icon-svg">
                 <path d="M15.084 15.2H.916a.264.264 0 0 1-.254-.42l2.36-4.492a.865.865 0 0 1 .696-.42h.827a9.51 9.51 0 0 0 .943 1.108H3.912l-1.637 3.116h11.45l-1.637-3.116h-1.34a9.481 9.481 0 0 0 .943-1.109h.591a.866.866 0 0 1 .696.421l2.36 4.492a.264.264 0 0 1-.254.42zM11.4 7.189c0 2.64-2.176 2.888-3.103 5.46a.182.182 0 0 1-.356 0c-.928-2.572-3.104-2.82-3.104-5.46a3.282 3.282 0 0 1 6.563 0zm-1.86-.005a1.425 1.425 0 1 0-1.425 1.425A1.425 1.425 0 0 0 9.54 7.184z"/>
             </svg>
         </button>
 
         <!-- Crouch Down Button -->
         <button id="crouch-btn" class="hud-btn" onclick="sendRobotAction('crouch')" title="Crouch Down (Q key)">
-            <svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" transform="scale(1, -1)">
+            <svg width="60px" height="60px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg" transform="scale(1, -1)">
                 <path d="M12 17L12 8" stroke="#ef4444" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
                 <path d="M16 11L12 7L8 11" stroke="#ef4444" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
             </svg>


### PR DESCRIPTION
- Fixed flashlight turning off on first slider change after page load
  - Root cause: API 1007 (LED color) always interferes with API 1005 (flashlight) on Go2 firmware
  - Solution: Removed API 1007 call entirely from set_led_brightness()

- Fixed RAGE MODE blinking turning off flashlight
  - Root cause: RAGE MODE sends API 1007 with time=1, when it expires the robot resets flashlight
  - Solution: Re-send API 1005 after 1.2s delay to counteract expiring LED command

- Fixed RGB LED color not restoring to preset after RAGE MODE
  - Added _current_preset_color state variable to track and restore preset color

- Fixed Pose Mode icon not reverting to RAGE MODE visual state
  - Updated updatePoseModeIndicator() to restore red color + glow when exiting Pose Mode

All flashlight/LED control now works correctly with proper priority system:
- Flashlight is always priority #1
- RGB LED changes are queued when flashlight is on
- RAGE MODE blinking pauses when flashlight turns on
- RAGE MODE blinking resumes when flashlight turns off